### PR TITLE
Now using natbib for APA citations

### DIFF
--- a/itex-templates/apa/export.bib
+++ b/itex-templates/apa/export.bib
@@ -12,4 +12,5 @@
    title = {Assessment of the selected parameters of aerodynamics for Airbus A380 aircraft on the basis of CFD tests},
    volume = {40},
    year = {2019},
+   urldate = {2023-02-14}
 }

--- a/itex-templates/apa/main.tex
+++ b/itex-templates/apa/main.tex
@@ -4,7 +4,7 @@
 \usepackage{amsmath}
 \usepackage{amssymb}
 \usepackage{siunitx}
-\usepackage{natbib}
+\usepackage[natbibapa]{apacite}
 \usepackage{url}
 \usepackage{graphicx}
 \usepackage{float}
@@ -25,10 +25,12 @@
 \newpage
 
 
+This is a citation \citep{Olejniczak2019}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %References
 \newpage
 \bibliography{export}
-\bibliographystyle{apa} %Sets the refrence style
+\bibliographystyle{apacite} %Sets the refrence style
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \end{document}


### PR DESCRIPTION
I switched the citations in the APA template to use `natbib` as it has better results, especially since it includes the `URLDATE` attribute. I also added a `makefile `which was missing 